### PR TITLE
Don't track initial / view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ app.use(VueMatomo, {
   host: 'https://thebristolcable.matomo.cloud',
   siteId: 1,
   router,
+  trackInitialView: false, // Seems to always track / as initial view
   enableLinkTracking: true,
   enableHeartBeatTimer: true,
   cookieDomain: '*.thebristolcable.org',


### PR DESCRIPTION
The initial page view always seems to be the root (/) regardless of the page the user landed on. The real initial page is triggered subsequently anyway so just remove the extra initial page view